### PR TITLE
Add CI/CD workflows and EAS build configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Nothing here writes to the repo, and pull requests from forks run this too.
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Format, lint & typecheck
@@ -16,6 +20,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Format, lint & typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Each check runs even if an earlier one failed, so a single run reports
+      # everything that needs fixing instead of just the first failure.
+      - name: Format
+        if: '!cancelled()'
+        run: pnpm format
+
+      - name: Lint
+        if: '!cancelled()'
+        run: pnpm lint
+
+      - name: Typecheck
+        if: '!cancelled()'
+        run: pnpm typecheck

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -35,6 +35,10 @@ concurrency:
   group: eas-build-${{ github.ref }}
   cancel-in-progress: false
 
+# The build only reads the repo; EAS is what it pushes to, not GitHub.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ inputs.profile || 'production' }} (${{ inputs.platform || 'all' }})
@@ -55,6 +59,8 @@ jobs:
           fi
 
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
 
@@ -63,15 +69,17 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
+      # EAS installs and builds the project on its own workers, but the CLI
+      # still needs the local install to read app.config.ts. Install runs
+      # before the Expo token is put in the environment, so a compromised
+      # dependency's install script has nothing to read.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - uses: expo/expo-github-action@v8
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
-
-      # EAS installs and builds the project on its own workers, but the CLI
-      # still needs the local install to read app.config.ts.
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Start EAS build
         working-directory: apps/mobile

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,0 +1,91 @@
+name: EAS build
+
+# Builds @lfc/mobile on EAS. Runs on demand, and automatically for release
+# tags (`v1.2.3`), which produce a production build of both platforms.
+#
+# Requires an `EXPO_TOKEN` repository secret — a personal access token from
+# https://expo.dev/settings/access-tokens for the `nanberg` account.
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Platform to build for
+        type: choice
+        default: all
+        options: [all, ios, android]
+      profile:
+        description: Build profile from eas.json
+        type: choice
+        default: production
+        options:
+          - production
+          - preview
+          - preview-simulator
+          - development
+          - development-simulator
+      submit:
+        description: Submit to the store when the build finishes (iOS only)
+        type: boolean
+        default: false
+  push:
+    tags: ['v*']
+
+# Never cancel a build in flight — EAS keeps running it server side anyway.
+concurrency:
+  group: eas-build-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: ${{ inputs.profile || 'production' }} (${{ inputs.platform || 'all' }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      PLATFORM: ${{ inputs.platform || 'all' }}
+      PROFILE: ${{ inputs.profile || 'production' }}
+      SUBMIT: ${{ inputs.submit || false }}
+    steps:
+      - name: Check for EXPO_TOKEN
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          if [ -z "$EXPO_TOKEN" ]; then
+            echo "::error::EXPO_TOKEN is not set. Create one at https://expo.dev/settings/access-tokens and add it as a repository secret."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      # EAS installs and builds the project on its own workers, but the CLI
+      # still needs the local install to read app.config.ts.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Start EAS build
+        working-directory: apps/mobile
+        run: |
+          set -- --non-interactive --no-wait --platform "$PLATFORM" --profile "$PROFILE"
+          if [ "$SUBMIT" = "true" ]; then
+            set -- "$@" --auto-submit
+          fi
+          eas build "$@"
+
+      - name: Summary
+        run: |
+          {
+            echo "Started a **$PROFILE** build of **$PLATFORM**."
+            echo
+            echo "Follow it at <https://expo.dev/accounts/nanberg/projects/lfc/builds>."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,7 +11,8 @@
     "format": "oxfmt --check",
     "format:fix": "oxfmt",
     "android": "expo run:android",
-    "ios": "expo run:ios"
+    "ios": "expo run:ios",
+    "eas-build-post-install": "pnpm --filter @lfc/api build"
   },
   "dependencies": {
     "@expo/dom-webview": "^57.0.1",

--- a/apps/worker/src/app.ts
+++ b/apps/worker/src/app.ts
@@ -26,9 +26,7 @@ export function createApp(
   // function receives the original path. Local dev uses the same paths.
   const app = new Hono().basePath('/api')
 
-  app.get('/health', (c) =>
-    c.json({ service: 'lfc-worker', status: 'ok' }),
-  )
+  app.get('/health', (c) => c.json({ service: 'lfc-worker', status: 'ok' }))
 
   // Register a device to receive new-article push notifications.
   app.post('/devices', async (c) => {

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,29 @@ pnpm --filter @lfc/mobile dev          # expo start
 pnpm --filter @lfc/worker dev          # local Hono server
 ```
 
+## CI/CD
+
+Two GitHub Actions workflows live in [`.github/workflows`](.github/workflows):
+
+| Workflow                                           | Trigger                             | What it does                         |
+| -------------------------------------------------- | ----------------------------------- | ------------------------------------ |
+| [`ci.yml`](.github/workflows/ci.yml)               | pushes to `main`, pull requests     | `pnpm format`, `lint`, `typecheck`   |
+| [`eas-build.yml`](.github/workflows/eas-build.yml) | manual dispatch, tags matching `v*` | starts an EAS build of `@lfc/mobile` |
+
+To run a build by hand, open **Actions → EAS build → Run workflow** and pick a
+platform and an [`eas.json`](apps/mobile/eas.json) profile; pushing a `v*` tag
+builds `production` for both platforms. Builds are started with `--no-wait`, so
+the workflow finishes as soon as EAS has queued the job — track progress on
+[expo.dev](https://expo.dev/accounts/nanberg/projects/lfc/builds).
+
+The build workflow needs an `EXPO_TOKEN` repository secret
+(**Settings → Secrets and variables → Actions**), created from a personal
+access token at
+[expo.dev/settings/access-tokens](https://expo.dev/settings/access-tokens).
+
+Because `@lfc/api` is consumed from its compiled `dist/`, `@lfc/mobile` has an
+`eas-build-post-install` hook that builds it on the EAS worker after install.
+
 ## Apps
 
 ### 📱 `@lfc/mobile`


### PR DESCRIPTION
This PR establishes automated CI/CD pipelines for the project using GitHub Actions and EAS (Expo Application Services).

## Summary
Added two GitHub Actions workflows to automate code quality checks and mobile app builds, along with supporting configuration for EAS builds.

## Key Changes

- **CI workflow** (`ci.yml`): Runs on pushes to `main` and pull requests to execute `pnpm format`, `lint`, and `typecheck` commands. All checks run independently so multiple issues are reported in a single workflow run.

- **EAS build workflow** (`eas-build.yml`): Triggered manually or automatically on version tags (`v*`). Supports configurable platform selection (iOS, Android, or both) and build profiles (production, preview, development, etc.). Includes optional auto-submit to app stores for iOS builds.

- **Post-install hook** in `@lfc/mobile`: Added `eas-build-post-install` script to build `@lfc/api` on EAS workers after dependency installation, ensuring the compiled `dist/` is available for consumption.

- **Documentation**: Updated `readme.md` with a CI/CD section explaining the workflows, how to trigger builds manually, and the required `EXPO_TOKEN` repository secret setup.

- **Minor formatting**: Fixed line wrapping in `apps/worker/src/app.ts` for consistency.

## Implementation Details

- The EAS build workflow uses `--no-wait` to queue builds asynchronously, allowing the workflow to complete while builds continue on EAS servers
- Concurrency is configured to prevent cancellation of in-flight builds
- The workflow validates the presence of `EXPO_TOKEN` before attempting to build
- Build progress can be tracked at `expo.dev/accounts/nanberg/projects/lfc/builds`

https://claude.ai/code/session_01Lyxy3RPJCmp55YAb1jR9wW